### PR TITLE
Drop target of SwiftPM package to lowest possible

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "ReactiveTimelane",
     platforms: [
-        .macOS(.v10_14), .iOS(.v12), .tvOS(.v12), .watchOS(.v5)
+        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
         .library(name: "ReactiveTimelane", targets: ["ReactiveTimelane"]),


### PR DESCRIPTION
## Summary
This PR drops the required target of the SwiftPM package to:
- macOS 10.10
- iOS 8
- tvOS 9
- watchOS 2

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This makes it possible to include the library in projects which are targeting lower versions than the required ones for the extension (macOS 10.14, iOS 12, tvOS 12, watchOS 5) and use the extension conditionally with an `#if available` statement.

## Details
<!-- Describe your changes in detail -->
Modified the `Package.swift` to include the target versions.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have written/altered unit tests for the changes.
- [x] Only necessary files have been added/altered.
