### PR TITLE
Add lane operator for Lifetime

### DIFF
--- a/Sources/ReactiveTimelane/ReactiveTimelane.swift
+++ b/Sources/ReactiveTimelane/ReactiveTimelane.swift
@@ -86,3 +86,25 @@ public extension SignalProducer {
         lift { $0.lane(name, filter: filter, transformValue: transform, logger: logger) }
     }
 }
+
+@available(macOS 10.14, iOS 12, tvOS 12, watchOS 5, *)
+public extension Lifetime {
+    /// The `lane` operator logs the lifetime to the Timelane Instrument.
+    ///
+    ///  - Note: You can download the Timelane Instrument from http://timelane.tools
+    /// - Parameters:
+    ///   - name: A name for the lane when visualized in Instruments
+    func lane(_ name: String,
+              file: StaticString = #file,
+              function: StaticString = #function,
+              line: UInt = #line,
+              logger: @escaping Timelane.Logger = Timelane.defaultLogger) {
+        let fileName = file.description.components(separatedBy: "/").last!
+        let source = "\(fileName):\(line) - \(function)"
+        let subscription = Timelane.Subscription(name: name, logger: logger)
+        subscription.begin(source: source)
+        self += observeEnded {
+            subscription.end(state: .completed)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds the `lane(_:)` operator for `Lifetime`.

## Motivation and Context
This makes it possible to also track the lifetime of objects.

## Details
Added an extension method for `Lifetime`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have written/altered unit tests for the changes.
- [x] Only necessary files have been added/altered.
