### PR TITLE
Update iOS deployment target to 9.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "ReactiveTimelane",
     platforms: [
-        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+        .macOS(.v10_10), .iOS(.v), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
         .library(name: "ReactiveTimelane", targets: ["ReactiveTimelane"]),

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "ReactiveTimelane",
     platforms: [
-        .macOS(.v10_10), .iOS(.v), .tvOS(.v9), .watchOS(.v2)
+        .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
         .library(name: "ReactiveTimelane", targets: ["ReactiveTimelane"]),


### PR DESCRIPTION
## Summary
ReactiveSwift and TimelaneCore requires iOS deployment target 9.0 
